### PR TITLE
Fix formatting of maintainer and source fields in config.conf

### DIFF
--- a/.github/workflows/config.conf
+++ b/.github/workflows/config.conf
@@ -3,6 +3,6 @@ PKGNAME=RivalCfgGuiGTK
 PKGVER=0.9.0
 ARCH=x86_64
 BUILD_DATE=20240626
-MAINTAINER=Chad Sheridan <chad.sheridan@cysec.ca>
+MAINTAINER="Chad Sheridan <chad.sheridan@cysec.ca>"
 LICENSE=GPL-3.0-or-later
 SOURCE=https://github.com/chads/RivalCfgGuiGTK/archive/refs/tags/v0.9.0.tar.gz


### PR DESCRIPTION
Correct the formatting of the maintainer and source fields in the configuration file for consistency.