### PR TITLE
Remove libxdo dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 glib = "0.18"
 gio = "0.18"
 anyhow = "1.0"
-tray-icon = "0.19"
+tray-icon = { version = "0.19", default-features = false }
 image = "0.25"
 gdk-pixbuf = "0.18"
 gtk = "0.18"


### PR DESCRIPTION
`libxdo` doesn't seem to be needed or used at all in the code (from what I can see). It's also an X11 thing. It was being pulled as a default dependency of `tray-icon`. Disabling `default-features` for `tray-icon` stops the library from being pulled and the app still runs fine. 